### PR TITLE
travis: use newer gcc (4.9) to avoid initialisation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ sudo: false
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
     - cmake
     - libpython2.7
@@ -33,13 +35,17 @@ addons:
     - libvorbis-dev
     - openssh-client
     - python-dev
+    - g++-4.9
     
     # not needed for building
     - gdb
+    env:
+      - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
   ssh_known_hosts: frs.sourceforge.net
 
 before_install:
+  - eval "${MATRIX_EVAL}"
   - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install sdl openal-soft freetype sdl_mixer libpng libvorbis; fi
   - touch id_travissfbot
   - if [[ $TRAVIS_SECURE_ENV_VARS == "true" ]]; then openssl aes-256-cbc -K $encrypted_798b15af9f34_key -iv $encrypted_798b15af9f34_iv -in testing/id_travissfbot.enc -out id_travissfbot -d; fi


### PR DESCRIPTION
let's see if 4.9 does it.