### PR TITLE
IWD2: scrollbar hides list of save games

### DIFF
--- a/gemrb/GUIScripts/iwd2/GUILOAD.py
+++ b/gemrb/GUIScripts/iwd2/GUILOAD.py
@@ -74,7 +74,7 @@ def OnLoad ():
 	Games=GemRB.GetSaveGames()
 	TopIndex = max (0, len(Games) - 5)
 
-	ScrollBar.SetVarAssoc ("TopIndex", len(Games))
+	ScrollBar.SetVarAssoc ("TopIndex", TopIndex, 0, TopIndex)
 	ScrollBarPress ()
 	LoadWindow.Focus()
 	return


### PR DESCRIPTION
Just a minor annoyance fix, as it otherwise needs some more clicks to go up the list of savegames that the scrollbar went down too far.